### PR TITLE
Allow commands of the same name as the package name in releases

### DIFF
--- a/__tests__/release/__snapshots__/release-bin-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-minimal-test.js.snap
@@ -3,13 +3,13 @@
 exports[`installation 1`] = `
 "<root>
 | bin
-| | minimal
+| | minimal-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | minimal
 | | | | .bin
-| | | | | minimal
+| | | | | minimal-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -59,7 +59,7 @@ exports[`installation 1`] = `
 `;
 
 exports[`installation stdout 1`] = `
-"/tmp/TMPDIR/npm/bin/minimal -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal
+"/tmp/TMPDIR/npm/bin/minimal-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal-esy-sandbox
 
 > minimal@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/minimal
 > ./postinstall.sh
@@ -74,7 +74,7 @@ exports[`release 1`] = `
 "<root>
 | bin-darwin
 | | .bin
-| | | minimal
+| | | minimal-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-bin-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-binary
+| | with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-binary
+| | | | | with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -64,7 +64,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary
+/tmp/TMPDIR/npm/bin/with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary-esy-sandbox
 
 > with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-binary
 > ./postinstall.sh
@@ -80,7 +80,7 @@ exports[`release 1`] = `
 | bin-darwin
 | | .bin
 | | | say-hello.exe
-| | | with-binary
+| | | with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-bin-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-with-dep-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-dep-with-binary
+| | with-dep-with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-dep-with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-dep-with-binary
+| | | | | with-dep-with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -80,7 +80,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-dep-with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary
+/tmp/TMPDIR/npm/bin/with-dep-with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary-esy-sandbox
 
 > with-dep-with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary
 > ./postinstall.sh
@@ -96,7 +96,7 @@ exports[`release 1`] = `
 | bin-darwin
 | | .bin
 | | | say-hello.exe
-| | | with-dep-with-binary
+| | | with-dep-with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-dev-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-minimal-test.js.snap
@@ -3,13 +3,13 @@
 exports[`installation 1`] = `
 "<root>
 | bin
-| | minimal
+| | minimal-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | minimal
 | | | | .bin
-| | | | | minimal
+| | | | | minimal-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -59,7 +59,7 @@ exports[`installation 1`] = `
 `;
 
 exports[`installation stdout 1`] = `
-"/tmp/TMPDIR/npm/bin/minimal -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal
+"/tmp/TMPDIR/npm/bin/minimal-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal-esy-sandbox
 
 > minimal@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/minimal
 > ./postinstall.sh
@@ -80,7 +80,7 @@ exports[`release 1`] = `
 "<root>
 | dev
 | | .bin
-| | | minimal
+| | | minimal-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-dev-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-binary
+| | with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-binary
+| | | | | with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -64,7 +64,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary
+/tmp/TMPDIR/npm/bin/with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary-esy-sandbox
 
 > with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-binary
 > ./postinstall.sh
@@ -86,7 +86,7 @@ exports[`release 1`] = `
 | dev
 | | .bin
 | | | say-hello.exe
-| | | with-binary
+| | | with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-dev-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-with-dep-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-dep-with-binary
+| | with-dep-with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-dep-with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-dep-with-binary
+| | | | | with-dep-with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -80,7 +80,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-dep-with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary
+/tmp/TMPDIR/npm/bin/with-dep-with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary-esy-sandbox
 
 > with-dep-with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary
 > ./postinstall.sh
@@ -104,7 +104,7 @@ exports[`release 1`] = `
 | dev
 | | .bin
 | | | say-hello.exe
-| | | with-dep-with-binary
+| | | with-dep-with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-pack-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-minimal-test.js.snap
@@ -3,13 +3,13 @@
 exports[`installation 1`] = `
 "<root>
 | bin
-| | minimal
+| | minimal-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | minimal
 | | | | .bin
-| | | | | minimal
+| | | | | minimal-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -59,7 +59,7 @@ exports[`installation 1`] = `
 `;
 
 exports[`installation stdout 1`] = `
-"/tmp/TMPDIR/npm/bin/minimal -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal
+"/tmp/TMPDIR/npm/bin/minimal-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/minimal/.bin/minimal-esy-sandbox
 
 > minimal@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/minimal
 > ./postinstall.sh
@@ -78,7 +78,7 @@ exports[`release 1`] = `
 "<root>
 | pack
 | | .bin
-| | | minimal
+| | | minimal-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-pack-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-binary
+| | with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-binary
+| | | | | with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -64,7 +64,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary
+/tmp/TMPDIR/npm/bin/with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-binary/.bin/with-binary-esy-sandbox
 
 > with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-binary
 > ./postinstall.sh
@@ -84,7 +84,7 @@ exports[`release 1`] = `
 | pack
 | | .bin
 | | | say-hello.exe
-| | | with-binary
+| | | with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/__tests__/release/__snapshots__/release-pack-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-with-dep-with-binary-test.js.snap
@@ -4,14 +4,14 @@ exports[`installation 1`] = `
 "<root>
 | bin
 | | say-hello.exe
-| | with-dep-with-binary
+| | with-dep-with-binary-esy-sandbox
 | etc
 | lib
 | | node_modules
 | | | with-dep-with-binary
 | | | | .bin
 | | | | | say-hello.exe
-| | | | | with-dep-with-binary
+| | | | | with-dep-with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
@@ -80,7 +80,7 @@ exports[`installation 1`] = `
 
 exports[`installation stdout 1`] = `
 "/tmp/TMPDIR/npm/bin/say-hello.exe -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/say-hello.exe
-/tmp/TMPDIR/npm/bin/with-dep-with-binary -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary
+/tmp/TMPDIR/npm/bin/with-dep-with-binary-esy-sandbox -> /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary/.bin/with-dep-with-binary-esy-sandbox
 
 > with-dep-with-binary@0.1.0 postinstall /tmp/TMPDIR/npm/lib/node_modules/with-dep-with-binary
 > ./postinstall.sh
@@ -102,7 +102,7 @@ exports[`release 1`] = `
 | pack
 | | .bin
 | | | say-hello.exe
-| | | with-dep-with-binary
+| | | with-dep-with-binary-esy-sandbox
 | | package.json
 | | postinstall.sh
 | | prerelease.sh

--- a/src/release.js
+++ b/src/release.js
@@ -202,7 +202,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as bashgen from './builders/bashgen';
 import outdent from 'outdent';
-import {DESIRED_ESY_STORE_PATH_LENGTH} from './build-config';
+import {DESIRED_ESY_STORE_PATH_LENGTH, ESY_STORE_VERSION} from './build-config';
 
 type ReleaseType = 'dev' | 'pack' | 'bin';
 
@@ -211,8 +211,6 @@ type BuildReleaseConfig = {
   version: string,
   sandboxPath: string,
 };
-
-var storeVersion = '3.x.x';
 
 /**
  * TODO: Make this language agnostic. Nothing else in the eject/build process
@@ -329,7 +327,7 @@ var createLaunchBinSh = function(releaseType, pkg, binaryName) {
   return outdent`
     #!/bin/bash
 
-    export ESY__STORE_VERSION=${storeVersion}
+    export ESY__STORE_VERSION=${ESY_STORE_VERSION}
     ${launchBinScriptSupport}
     if [ -z \${${packageNameUppercase}__ENVIRONMENTSOURCED__${binaryNameUppercase}+x} ]; then
       if [ -z \${${packageNameUppercase}__ENVIRONMENTSOURCED+x} ]; then
@@ -793,7 +791,7 @@ var createInstallScript = function(releaseStage, releaseType, pkg) {
 
     export PACKAGE_ROOT="$SCRIPTDIR"
 
-    export ESY__STORE_VERSION="${storeVersion}"
+    export ESY__STORE_VERSION="${ESY_STORE_VERSION}"
 
     export ESY_EJECT__SANDBOX="$SCRIPTDIR/rel"
     export ESY_EJECT__ROOT="$ESY_EJECT__SANDBOX/node_modules/.cache/_esy/build-eject"

--- a/src/release.js
+++ b/src/release.js
@@ -375,6 +375,7 @@ async function deriveNpmReleasePackage(pkg, releasePath, releaseType) {
   // We don't manage dependencies with npm, esy is being installed via a
   // postinstall script and then it is used to manage release dependencies.
   copy.dependencies = {};
+  copy.peerDependencies = {};
   copy.devDependencies = {};
 
   // Populate "bin" metadata.


### PR DESCRIPTION
Now we generate release's sandbox entry point command as `<projectname>-esy-sandbox`, for example: `reason-cli-esy-sandbox`.