### PR TITLE
Make release postinstall script idempotent

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -334,7 +334,7 @@ function createCommandWrapper(pkg, commandName) {
       if [ -z \${${packageNameUppercase}__ENVIRONMENTSOURCED+x} ]; then
         ${bashgen.defineScriptDir}
         export ESY_EJECT__SANDBOX="$SCRIPTDIR/../rel"
-        export ESY_EJECT__ROOT="$ESY_EJECT__SANDBOX/node_modules/.cache/_esy/build-eject"
+        export ESY_EJECT__ROOT="$ESY_EJECT__SANDBOX/_esyEjectRoot"
         export PACKAGE_ROOT="$SCRIPTDIR/.."
         # Remove dependency on esy and package managers in general
         # We fake it so that the eject store is the location where we relocated the
@@ -592,6 +592,7 @@ function createInstallScript(releaseStage: ReleaseStage, releaseType: ReleaseTyp
     echo '*** Ejecting build environment...'
     cd $ESY_EJECT__SANDBOX
     $ESY_COMMAND build-eject
+    mv $ESY_EJECT__SANDBOX/node_modules/.cache/_esy/build-eject $ESY_EJECT__SANDBOX/_esyEjectRoot
     cd $PACKAGE_ROOT
 
   `;
@@ -797,7 +798,7 @@ function createInstallScript(releaseStage: ReleaseStage, releaseType: ReleaseTyp
     export ESY__STORE_VERSION="${ESY_STORE_VERSION}"
 
     export ESY_EJECT__SANDBOX="$SCRIPTDIR/rel"
-    export ESY_EJECT__ROOT="$ESY_EJECT__SANDBOX/node_modules/.cache/_esy/build-eject"
+    export ESY_EJECT__ROOT="$ESY_EJECT__SANDBOX/_esyEjectRoot"
 
     # We Build into the ESY_EJECT__STORE, copy into ESY_EJECT__TMP, potentially
     # transport over the network then finally we copy artifacts into the

--- a/src/release.js
+++ b/src/release.js
@@ -962,4 +962,12 @@ export async function buildRelease(config: BuildReleaseConfig) {
     path.join(releasePath, 'postinstall.sh'),
     createInstallScript('forClientInstallation', releaseType, pkg),
   );
+
+  console.log(outdent`
+    *** Release package created
+
+        Location: ${path.relative(process.cwd(), releasePath)}
+        Release Type: ${releaseType}
+
+  `);
 }


### PR DESCRIPTION
This fixes installation of released artefacts with yarn (see yarnpkg/yarn#932).

Fixes #11 